### PR TITLE
Bring back licensing info, add AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Steve Gigou (@sgigou)
+Alexey Ivanov (@AlexDjSun)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+“Commons Clause” License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you,  right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software.  Any license notice or attribution required by the License must also include this Commons Cause License Condition notice.
+
+License: GNU GPL v3
+Licensor: Steve Gigou

--- a/src/KomiKeyboard/AppDelegate.swift
+++ b/src/KomiKeyboard/AppDelegate.swift
@@ -1,11 +1,10 @@
-
-
-
-
-
-
-
-
+//
+//  AppDelegate.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-04-30.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/KomiKeyboard/UI/EditorViewController.swift
+++ b/src/KomiKeyboard/UI/EditorViewController.swift
@@ -1,4 +1,11 @@
-
+//
+//  EditorViewController.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 25/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/KomiKeyboard/UI/InstallViewController.swift
+++ b/src/KomiKeyboard/UI/InstallViewController.swift
@@ -1,4 +1,10 @@
-
+//
+//  InstallViewController.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 25/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 
@@ -13,7 +19,4 @@ class InstallViewController: UIViewController {
     }
   }
 
-    
-    
 }
-

--- a/src/KomiKeyboard/UI/LandingViewController.swift
+++ b/src/KomiKeyboard/UI/LandingViewController.swift
@@ -1,4 +1,11 @@
-
+//
+//  LandingViewController.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 25/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/KomiKeyboard/Utils/BepoKeymap.swift
+++ b/src/KomiKeyboard/Utils/BepoKeymap.swift
@@ -1,4 +1,11 @@
-
+//
+//  BepoKeymap.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 28/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/KomiKeyboard/Utils/DeadKeyConverter.swift
+++ b/src/KomiKeyboard/Utils/DeadKeyConverter.swift
@@ -1,4 +1,10 @@
-
+//
+//  DeadKeyConverter.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 29/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import Foundation
 

--- a/src/KomiKeyboard/Utils/Notification.swift
+++ b/src/KomiKeyboard/Utils/Notification.swift
@@ -1,3 +1,10 @@
+//
+//  Notification.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 28/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import Foundation
 

--- a/src/KomiKeyboard/Utils/Swift+Extension.swift
+++ b/src/KomiKeyboard/Utils/Swift+Extension.swift
@@ -1,4 +1,10 @@
-
+//
+//  Swift+Extension.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 28/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import Foundation
 

--- a/src/KomiKeyboardTests/ibepoTests.swift
+++ b/src/KomiKeyboardTests/ibepoTests.swift
@@ -2,7 +2,8 @@
 //  KomiKeyboardTests.swift
 //  KomiKeyboardTests
 //
-//  Created by Aleksei Ivanov on 2020-04-30.
+//  Created by Steve Gigou on 2020-04-30.
+//  Copyright © 2020 Novesoft. All rights reserved.
 //  Copyright © 2020 majbyr.com. All rights reserved.
 //
 

--- a/src/KomiKeyboardUITests/ibepoUITests.swift
+++ b/src/KomiKeyboardUITests/ibepoUITests.swift
@@ -2,7 +2,8 @@
 //  KomiKeyboardUITests.swift
 //  KomiKeyboardUITests
 //
-//  Created by Aleksei Ivanov on 2020-04-30.
+//  Created by Steve Gigou on 2020-04-30.
+//  Copyright © 2020 Novesoft. All rights reserved.
 //  Copyright © 2020 majbyr.com. All rights reserved.
 //
 

--- a/src/keyboard/Entities/Correction.swift
+++ b/src/keyboard/Entities/Correction.swift
@@ -1,3 +1,10 @@
+//
+//  Correction.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-19.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 
 // MARK: - Correction

--- a/src/keyboard/Entities/Key.swift
+++ b/src/keyboard/Entities/Key.swift
@@ -1,4 +1,11 @@
-
+//
+//  Key.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Entities/KeyCharacterSet.swift
+++ b/src/keyboard/Entities/KeyCharacterSet.swift
@@ -1,4 +1,10 @@
-
+//
+//  Key.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 
 /// All the character set of a key.

--- a/src/keyboard/Entities/KeySet.swift
+++ b/src/keyboard/Entities/KeySet.swift
@@ -1,4 +1,10 @@
-
+//
+//  KeySet.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import Foundation
 

--- a/src/keyboard/KeyboardViewController.swift
+++ b/src/keyboard/KeyboardViewController.swift
@@ -1,4 +1,10 @@
-
+//
+//  KeyboardViewController.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-02.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/AutoCapitalizer.swift
+++ b/src/keyboard/Services/AutoCapitalizer.swift
@@ -1,4 +1,10 @@
-
+//
+//  AutoCapitalizer.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-06-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 final class AutoCapitalizer {
   

--- a/src/keyboard/Services/Autocorrect.swift
+++ b/src/keyboard/Services/Autocorrect.swift
@@ -1,4 +1,11 @@
-
+//
+//  Autocorrect.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-19.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/DataManagement/ColorManager.swift
+++ b/src/keyboard/Services/DataManagement/ColorManager.swift
@@ -1,4 +1,10 @@
-
+//
+//  ColorManager.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-06.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/DataManagement/SymbolsManager.swift
+++ b/src/keyboard/Services/DataManagement/SymbolsManager.swift
@@ -1,4 +1,10 @@
-
+//
+//  SymbolsManager.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-06.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/KeyGesture/KeyGestureRecognizer.swift
+++ b/src/keyboard/Services/KeyGesture/KeyGestureRecognizer.swift
@@ -1,3 +1,11 @@
+//
+//  KeyGestureRecognizer.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-07.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 import AudioToolbox

--- a/src/keyboard/Services/KeyGesture/KeyLocator.swift
+++ b/src/keyboard/Services/KeyGesture/KeyLocator.swift
@@ -1,4 +1,11 @@
-
+//
+//  KeyLocator.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-25.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 final class KeyLocator {
   

--- a/src/keyboard/Services/KeyGesture/KeyboardProtocols.swift
+++ b/src/keyboard/Services/KeyGesture/KeyboardProtocols.swift
@@ -2,7 +2,8 @@
 //  KeyboardActionProtocol.swift
 //  keyboard
 //
-//  Created by Aleksei Ivanov on 2020-09-14.
+//  Created by Steve Gigou on 2020-05-14.
+//  Copyright © 2020 Novesoft. All rights reserved
 //  Copyright © 2020 majbyr.com. All rights reserved.
 //
 

--- a/src/keyboard/Services/KeyGesture/KeyboardState.swift
+++ b/src/keyboard/Services/KeyGesture/KeyboardState.swift
@@ -1,4 +1,10 @@
-
+//
+//  KeyboardState.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-07.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/KeySetFactory.swift
+++ b/src/keyboard/Services/KeySetFactory.swift
@@ -1,4 +1,11 @@
-
+//
+//  KeySetFactory.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 final class KeySetFactory {
   

--- a/src/keyboard/Services/KeyboardSettings.swift
+++ b/src/keyboard/Services/KeyboardSettings.swift
@@ -1,3 +1,10 @@
+//
+//  KeyboardSettings.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/TextDocumentProxyAnalyzer.swift
+++ b/src/keyboard/Services/TextDocumentProxyAnalyzer.swift
@@ -1,3 +1,10 @@
+//
+//  TextDocumentProxyAnalyzer.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-20.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Services/TextModifiers/DotInserter.swift
+++ b/src/keyboard/Services/TextModifiers/DotInserter.swift
@@ -1,4 +1,10 @@
-
+//
+//  DotInserter.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-06-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 final class DotInserter {
   

--- a/src/keyboard/Services/TextModifiers/NonBreakingSpaceInserter.swift
+++ b/src/keyboard/Services/TextModifiers/NonBreakingSpaceInserter.swift
@@ -1,4 +1,10 @@
-
+//
+//  NonBreakingSpaceInserter.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-06-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 
 class NonBreakingSpaceInserter {

--- a/src/keyboard/Services/TextModifiers/SpaceRemover.swift
+++ b/src/keyboard/Services/TextModifiers/SpaceRemover.swift
@@ -1,3 +1,10 @@
+//
+//  SpaceRemover.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-06-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import Foundation
 

--- a/src/keyboard/Services/TextModifiers/TextModifier.swift
+++ b/src/keyboard/Services/TextModifiers/TextModifier.swift
@@ -1,4 +1,10 @@
-
+//
+//  TextModifierProtocol.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-06-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 
 protocol TextModifier {

--- a/src/keyboard/Services/TextModifiers/TextModifiersFactory.swift
+++ b/src/keyboard/Services/TextModifiers/TextModifiersFactory.swift
@@ -1,4 +1,10 @@
-
+//
+//  TextModifiersFactory.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-06-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 
 final class TextModifiersFactory {

--- a/src/keyboard/UI/Autocorrect/AutocorrectViewController.swift
+++ b/src/keyboard/UI/Autocorrect/AutocorrectViewController.swift
@@ -1,4 +1,10 @@
-
+//
+//  AutocorrectViewController.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-20.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/UI/InputViewController.swift
+++ b/src/keyboard/UI/InputViewController.swift
@@ -1,4 +1,10 @@
-
+//
+//  InputViewController.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-02.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 import os.log

--- a/src/keyboard/UI/Keypad/KeypadView.swift
+++ b/src/keyboard/UI/Keypad/KeypadView.swift
@@ -1,4 +1,11 @@
-
+//
+//  KeypadView.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/UI/Keypad/KeypadViewController.swift
+++ b/src/keyboard/UI/Keypad/KeypadViewController.swift
@@ -1,4 +1,10 @@
-
+//
+//  KeypadViewController.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/UI/Keypad/Keys/KeyView.swift
+++ b/src/keyboard/UI/Keypad/Keys/KeyView.swift
@@ -1,4 +1,10 @@
-
+//
+//  KeyView.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/UI/Keypad/Keys/LetterKeyView.swift
+++ b/src/keyboard/UI/Keypad/Keys/LetterKeyView.swift
@@ -1,4 +1,10 @@
-
+//
+//  LetterKeyView.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/UI/Keypad/Keys/SpecialKeyView.swift
+++ b/src/keyboard/UI/Keypad/Keys/SpecialKeyView.swift
@@ -1,4 +1,10 @@
-
+//
+//  SystemKeyView.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/UI/Keypad/PopupView.swift
+++ b/src/keyboard/UI/Keypad/PopupView.swift
@@ -1,3 +1,10 @@
+//
+//  PopupView.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-29.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Utils/Constants.swift
+++ b/src/keyboard/Utils/Constants.swift
@@ -1,4 +1,11 @@
-
+//
+//  Constants.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-29.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Utils/Extensions.swift
+++ b/src/keyboard/Utils/Extensions.swift
@@ -1,3 +1,10 @@
+//
+//  UI+Extension.swift
+//  ibepo
+//
+//  Created by Steve Gigou on 2020-05-04.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import UIKit
 

--- a/src/keyboard/Utils/Notification.swift
+++ b/src/keyboard/Utils/Notification.swift
@@ -1,4 +1,10 @@
-
+//
+//  Notification.swift
+//  keyboard
+//
+//  Created by Steve Gigou on 2020-05-08.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//
 
 import Foundation
 

--- a/src/keyboard/Utils/UniversalLogger.swift
+++ b/src/keyboard/Utils/UniversalLogger.swift
@@ -1,4 +1,10 @@
-
+//
+//  UniversalLogger.swift
+//
+//  Created by Steve Gigou on 18/09/2020.
+//  Copyright © 2020 Novesoft. All rights reserved.
+//  Copyright © 2020 majbyr.com. All rights reserved.
+//
 
 import Foundation
 import os.log


### PR DESCRIPTION
You can't just remove licensing header or change the originator's name to yours, it's a violation. Let's respect the authorship:smile:

There's `ibepo` string in some comments which is no longer correct, I see no problem to leave it as is.